### PR TITLE
use native path separator for class name construction

### DIFF
--- a/src/main/scala/plugin.scala
+++ b/src/main/scala/plugin.scala
@@ -14,7 +14,7 @@ object Plugin extends sbt.Plugin {
     benchmarks in cappi := {
      val base = (scalaSource in Test).value
      (sources in Test).value.map {
-        IO.relativize(base, _).get.replace("/",".").replace(".scala", "")
+        IO.relativize(base, _).get.replace(java.io.File.separator,".").replace(".scala", "")
       }.filter(_.endsWith("Benchmark"))
     },
     libraryDependencies ++=


### PR DESCRIPTION
It currently fails on windows with `java.lang.NoClassDefFoundError: org\namespace\MyBenchmark (wrong name: org/namespace/MyBenchmark)`
